### PR TITLE
Register API cleanup

### DIFF
--- a/cli/debugger.cpp
+++ b/cli/debugger.cpp
@@ -40,10 +40,7 @@ bool Cli::handle_manual_stepping_mode(ExecutorBase &executor, uint32_t instructi
 					if (index > AARCH64_GENERAL_PURPOSE_REGISTERS) {
 						logger->error() << "Invalid register index" << std::endl;
 					} else {
-						uint64_t reg_value = reg_size == 64
-											 ? cpu.readRegister64(index, true)
-											 : cpu.readRegister32(index, true);
-
+						uint64_t reg_value = cpu.readRegisterSp(index, reg_size);
 						logger->error() << std::dec << std::noshowbase << 'X' << index << " = " << std::hex
 										<< std::showbase << reg_value << std::endl;
 					}

--- a/disassembly/instructions/loads_and_stores/indexing_helper.h
+++ b/disassembly/instructions/loads_and_stores/indexing_helper.h
@@ -13,10 +13,7 @@ namespace InstructionDefs::IndexingHelpers {
 			regindex_t base_reg,
 			bool is_wide = true
 	) {
-		uintptr_t virt_addr = is_wide
-							  ? cpu.readRegister64(base_reg, true)
-							  : cpu.readRegister32(base_reg, true);
-
+		uintptr_t virt_addr = cpu.readRegisterSp(base_reg, is_wide ? 64 : 32);
 		switch (mode) {
 			case InstructionDefs::IndexingMode::NonTemporalOffset:
 			case InstructionDefs::IndexingMode::SignedOffset:

--- a/disassembly/instructions/loads_and_stores/indexing_helper.h
+++ b/disassembly/instructions/loads_and_stores/indexing_helper.h
@@ -24,11 +24,11 @@ namespace InstructionDefs::IndexingHelpers {
 				virt_addr += immediate;
 				break;
 			case InstructionDefs::IndexingMode::PostIndex:
-				cpu.writeRegister64(base_reg, virt_addr + immediate, true);
+				cpu.writeRegisterSp(base_reg, virt_addr + immediate, 64);
 				break;
 			case InstructionDefs::IndexingMode::PreIndex:
 				virt_addr += immediate;
-				cpu.writeRegister64(base_reg, virt_addr, true);
+				cpu.writeRegisterSp(base_reg, virt_addr, 64);
 				break;
 			default:
 				throw std::runtime_error("Illegal indexing mode");

--- a/emulation/AArch64Cpu.cpp
+++ b/emulation/AArch64Cpu.cpp
@@ -14,6 +14,9 @@ namespace {
 		// + 1
 		return (((1 << (size - 1)) - 1) << 1) + 1;
 	}
+	inline bool is_stack_pointer(const regindex_t index) {
+		return static_cast<Emulation::Registers>(index) == Emulation::Registers::Sp;
+	}
 }
 
 AArch64Cpu::AArch64Cpu() : _nzcvConditionRegister(0),
@@ -30,7 +33,7 @@ AArch64Cpu::AArch64Cpu() : _nzcvConditionRegister(0),
 
 void AArch64Cpu::writeRegisterSp(regindex_t index, uint64_t val, size_t size) {
 	check_regindex(index);
-	if (static_cast<Emulation::Registers>(index) == Emulation::Registers::Sp) {
+	if (is_stack_pointer(index)) {
 		this->getMemory().getStack(AARCH64_MAIN_THREAD_ID)->setStackPointer(val);
 	}
 	else {
@@ -40,7 +43,7 @@ void AArch64Cpu::writeRegisterSp(regindex_t index, uint64_t val, size_t size) {
 
 void AArch64Cpu::writeRegister(regindex_t index, uint64_t val, size_t size) {
 	check_regindex(index);
-	if (static_cast<Emulation::Registers>(index) != Emulation::Registers::Sp) {
+	if (!is_stack_pointer(index)) {
 		this->_generalRegisters[index] = val & get_mask(size);
 	}
 }

--- a/emulation/AArch64Cpu.cpp
+++ b/emulation/AArch64Cpu.cpp
@@ -72,38 +72,6 @@ uint64_t AArch64Cpu::readRegister(regindex_t index, size_t size) const {
 	return this->_generalRegisters[index] & get_mask(size);
 }
 
-//uint32_t AArch64Cpu::readRegister32(regindex_t index, bool useSp) const {
-//	check_regindex(index);
-//
-//	switch (static_cast<Emulation::Registers>(index)) {
-//		case Emulation::Registers::Sp:
-//			return useSp
-//				? this->getMemory().getStack(AARCH64_MAIN_THREAD_ID)->getStackPointer()
-//				: 0;
-//		default:
-//			return this->_generalRegisters[index];
-//	}
-//}
-//uint32_t AArch64Cpu::readRegister32(regindex_t index) const {
-//	return readRegister32(index, false);
-//}
-//
-//uint64_t AArch64Cpu::readRegister64(regindex_t index, bool useSp) const {
-//	check_regindex(index);
-//
-//	switch (static_cast<Emulation::Registers>(index)) {
-//		case Emulation::Registers::Sp:
-//			return useSp
-//				? this->getMemory().getStack(AARCH64_MAIN_THREAD_ID)->getStackPointer()
-//				: 0;
-//		default:
-//			return this->_generalRegisters[index];
-//	}
-//}
-//uint64_t AArch64Cpu::readRegister64(regindex_t index) const {
-//	return readRegister64(index, false);
-//}
-
 CpuVirtualMemory & AArch64Cpu::getMemory() const {
 	return *this->_memory;
 }

--- a/emulation/AArch64Cpu.cpp
+++ b/emulation/AArch64Cpu.cpp
@@ -49,11 +49,27 @@ void AArch64Cpu::writeRegister(regindex_t index, uint64_t val, size_t size) {
 }
 
 uint64_t AArch64Cpu::readRegisterSp(regindex_t index, size_t size) const {
-	throw std::runtime_error("Todo: implement");
+	check_regindex(index);
+
+	uint64_t val = 0;
+	if (is_stack_pointer(index)) {
+		val = this->getMemory().getStack(AARCH64_MAIN_THREAD_ID)->getStackPointer();
+	}
+	else {
+		val = this->_generalRegisters[index];
+	}
+
+	return val & get_mask(size);
 }
 
 uint64_t AArch64Cpu::readRegister(regindex_t index, size_t size) const {
-	throw std::runtime_error("Todo: implement");
+	check_regindex(index);
+
+	if (is_stack_pointer(index)) {
+		return 0;
+	}
+
+	return this->_generalRegisters[index] & get_mask(size);
 }
 
 //uint32_t AArch64Cpu::readRegister32(regindex_t index, bool useSp) const {

--- a/emulation/AArch64Cpu.cpp
+++ b/emulation/AArch64Cpu.cpp
@@ -45,37 +45,45 @@ void AArch64Cpu::writeRegister(regindex_t index, uint64_t val, size_t size) {
 	}
 }
 
-uint32_t AArch64Cpu::readRegister32(regindex_t index, bool useSp) const {
-	check_regindex(index);
-
-	switch (static_cast<Emulation::Registers>(index)) {
-		case Emulation::Registers::Sp:
-			return useSp
-				? this->getMemory().getStack(AARCH64_MAIN_THREAD_ID)->getStackPointer()
-				: 0;
-		default:
-			return this->_generalRegisters[index];
-	}
-}
-uint32_t AArch64Cpu::readRegister32(regindex_t index) const {
-	return readRegister32(index, false);
+uint64_t AArch64Cpu::readRegisterSp(regindex_t index, size_t size) const {
+	throw std::runtime_error("Todo: implement");
 }
 
-uint64_t AArch64Cpu::readRegister64(regindex_t index, bool useSp) const {
-	check_regindex(index);
+uint64_t AArch64Cpu::readRegister(regindex_t index, size_t size) const {
+	throw std::runtime_error("Todo: implement");
+}
 
-	switch (static_cast<Emulation::Registers>(index)) {
-		case Emulation::Registers::Sp:
-			return useSp
-				? this->getMemory().getStack(AARCH64_MAIN_THREAD_ID)->getStackPointer()
-				: 0;
-		default:
-			return this->_generalRegisters[index];
-	}
-}
-uint64_t AArch64Cpu::readRegister64(regindex_t index) const {
-	return readRegister64(index, false);
-}
+//uint32_t AArch64Cpu::readRegister32(regindex_t index, bool useSp) const {
+//	check_regindex(index);
+//
+//	switch (static_cast<Emulation::Registers>(index)) {
+//		case Emulation::Registers::Sp:
+//			return useSp
+//				? this->getMemory().getStack(AARCH64_MAIN_THREAD_ID)->getStackPointer()
+//				: 0;
+//		default:
+//			return this->_generalRegisters[index];
+//	}
+//}
+//uint32_t AArch64Cpu::readRegister32(regindex_t index) const {
+//	return readRegister32(index, false);
+//}
+//
+//uint64_t AArch64Cpu::readRegister64(regindex_t index, bool useSp) const {
+//	check_regindex(index);
+//
+//	switch (static_cast<Emulation::Registers>(index)) {
+//		case Emulation::Registers::Sp:
+//			return useSp
+//				? this->getMemory().getStack(AARCH64_MAIN_THREAD_ID)->getStackPointer()
+//				: 0;
+//		default:
+//			return this->_generalRegisters[index];
+//	}
+//}
+//uint64_t AArch64Cpu::readRegister64(regindex_t index) const {
+//	return readRegister64(index, false);
+//}
 
 CpuVirtualMemory & AArch64Cpu::getMemory() const {
 	return *this->_memory;

--- a/emulation/AArch64Cpu.h
+++ b/emulation/AArch64Cpu.h
@@ -35,11 +35,6 @@ public:
 	[[nodiscard]] uint64_t getProgramCounter() const;
 	void setProgramCounter(uint64_t pc);
 
-//	[[nodiscard]] uint32_t readRegister32(regindex_t index, bool useSp) const;
-//    [[nodiscard]] uint32_t readRegister32(regindex_t index) const;
-//	[[nodiscard]] uint64_t readRegister64(regindex_t index, bool useSp) const;
-//    [[nodiscard]] uint64_t readRegister64(regindex_t index) const;
-
 	/**
 	 * Reads the nzcv register (condition flags)
 	 * @return nzcv register value

--- a/emulation/AArch64Cpu.h
+++ b/emulation/AArch64Cpu.h
@@ -26,13 +26,6 @@ private:
 public:
     AArch64Cpu();
 
-//    void writeRegister32(regindex_t index, uint32_t val, bool useSp);
-//	void writeRegister32(regindex_t index, uint32_t val);
-//    void writeRegister64(regindex_t index, uint64_t val, bool useSp);
-//	void writeRegister64(regindex_t index, uint64_t val);
-//	void writeRegister64(Emulation::Registers registerName, uint64_t val, bool useSp);
-//	void writeRegister64(Emulation::Registers registerName, uint64_t val);
-
 	void writeRegisterSp(regindex_t index, uint64_t val, size_t size);
 	void writeRegister(regindex_t index, uint64_t val, size_t size);
 

--- a/emulation/AArch64Cpu.h
+++ b/emulation/AArch64Cpu.h
@@ -29,13 +29,16 @@ public:
 	void writeRegisterSp(regindex_t index, uint64_t val, size_t size);
 	void writeRegister(regindex_t index, uint64_t val, size_t size);
 
+	[[nodiscard]] uint64_t readRegisterSp(regindex_t index, size_t size) const;
+	[[nodiscard]] uint64_t readRegister(regindex_t index, size_t size) const;
+
 	[[nodiscard]] uint64_t getProgramCounter() const;
 	void setProgramCounter(uint64_t pc);
 
-	[[nodiscard]] uint32_t readRegister32(regindex_t index, bool useSp) const;
-    [[nodiscard]] uint32_t readRegister32(regindex_t index) const;
-	[[nodiscard]] uint64_t readRegister64(regindex_t index, bool useSp) const;
-    [[nodiscard]] uint64_t readRegister64(regindex_t index) const;
+//	[[nodiscard]] uint32_t readRegister32(regindex_t index, bool useSp) const;
+//    [[nodiscard]] uint32_t readRegister32(regindex_t index) const;
+//	[[nodiscard]] uint64_t readRegister64(regindex_t index, bool useSp) const;
+//    [[nodiscard]] uint64_t readRegister64(regindex_t index) const;
 
 	/**
 	 * Reads the nzcv register (condition flags)

--- a/emulation/AArch64Cpu.h
+++ b/emulation/AArch64Cpu.h
@@ -26,12 +26,15 @@ private:
 public:
     AArch64Cpu();
 
-    void writeRegister32(regindex_t index, uint32_t val, bool useSp);
-	void writeRegister32(regindex_t index, uint32_t val);
-    void writeRegister64(regindex_t index, uint64_t val, bool useSp);
-	void writeRegister64(regindex_t index, uint64_t val);
-	void writeRegister64(Emulation::Registers registerName, uint64_t val, bool useSp);
-	void writeRegister64(Emulation::Registers registerName, uint64_t val);
+//    void writeRegister32(regindex_t index, uint32_t val, bool useSp);
+//	void writeRegister32(regindex_t index, uint32_t val);
+//    void writeRegister64(regindex_t index, uint64_t val, bool useSp);
+//	void writeRegister64(regindex_t index, uint64_t val);
+//	void writeRegister64(Emulation::Registers registerName, uint64_t val, bool useSp);
+//	void writeRegister64(Emulation::Registers registerName, uint64_t val);
+
+	void writeRegisterSp(regindex_t index, uint64_t val, size_t size);
+	void writeRegister(regindex_t index, uint64_t val, size_t size);
 
 	[[nodiscard]] uint64_t getProgramCounter() const;
 	void setProgramCounter(uint64_t pc);

--- a/emulation/CpuVirtualMemory.cpp
+++ b/emulation/CpuVirtualMemory.cpp
@@ -202,3 +202,11 @@ void *CpuVirtualMemory::getUnsafePointer(virtual_address_t virtualAddress) {
 		return reinterpret_cast<void *>(segment.data() + index);
 	}
 }
+
+void CpuVirtualMemory::write_u32(uintptr_t addr, uint32_t value) {
+	write(addr, value);
+}
+
+void CpuVirtualMemory::write_u64(uintptr_t addr, uint64_t value) {
+	write(addr, value);
+}

--- a/emulation/CpuVirtualMemory.h
+++ b/emulation/CpuVirtualMemory.h
@@ -53,6 +53,9 @@ public:
 	void write(uintptr_t addr, uint32_t value);
 	void write(uintptr_t addr, uint64_t value);
 
+	void write_u32(uintptr_t addr, uint32_t value);
+	void write_u64(uintptr_t addr, uint64_t value);
+
 	void write(virtual_address_t destination,
 			   std::vector<std::byte>::const_iterator begin,
 			   std::vector<std::byte>::difference_type size);

--- a/emulation/executors/begsi/BranchingExecutor.h
+++ b/emulation/executors/begsi/BranchingExecutor.h
@@ -20,7 +20,7 @@ namespace Executors::Begsi {
 		uint64_t pc = cpu.getProgramCounter();
 
 		if (isLink) {
-			cpu.writeRegister64(30, pc + 4);
+			cpu.writeRegister(30, pc + 4, 64);
 		}
 
 		pc = destination;

--- a/emulation/executors/begsi/CompareAndBranchImmediateExecutor.cpp
+++ b/emulation/executors/begsi/CompareAndBranchImmediateExecutor.cpp
@@ -2,9 +2,7 @@
 
 void Executors::Begsi::CompareAndBranchImmediateExecutor::execute(
 		const InstructionDefs::Begsi::CompareAndBranchImmediate &instruction, AArch64Cpu &cpu) {
-	const uint64_t val = instruction.is64bit
-			? cpu.readRegister64(instruction.index, false)
-			: cpu.readRegister32(instruction.index, false);
+	const uint64_t val = cpu.readRegister(instruction.index, instruction.is64bit ? 64 : 32);
 	const bool isNonZero = val != 0;
 	const bool doBranch = isNonZero && instruction.branchIfNonZero || !isNonZero && !instruction.branchIfNonZero;
 

--- a/emulation/executors/begsi/UnconditionalBranchRegisterExecutor.cpp
+++ b/emulation/executors/begsi/UnconditionalBranchRegisterExecutor.cpp
@@ -3,7 +3,7 @@
 void
 Executors::Begsi::UnconditionalBranchRegisterExecutor::execute(
 		const InstructionDefs::Begsi::UnconditionalBranchRegister &instruction, AArch64Cpu& cpu) {
-	const virtual_address_t target = cpu.readRegister64(instruction.destination_reg);
+	const virtual_address_t target = cpu.readRegister(instruction.destination_reg, 64);
 	this->branchTo(
 			target,
 			Emulation::BranchType::IndirectCall,

--- a/emulation/executors/data_proc_imm/AddSubImmediateExecutor.cpp
+++ b/emulation/executors/data_proc_imm/AddSubImmediateExecutor.cpp
@@ -4,10 +4,7 @@
 
 void Executors::DataProcImm::AddSubImmediateExecutor::execute(
 		const InstructionDefs::DataProcImm::AddImmediate& instruction, AArch64Cpu& cpu) {
-    uint64_t val = instruction.is_64bit
-        ? cpu.readRegister64(instruction.source_reg_index, true)
-        : cpu.readRegister32(instruction.source_reg_index, true);
-
+    uint64_t val = cpu.readRegisterSp(instruction.source_reg_index, instruction.is_64bit ? 64 : 32);
 	uint16_t imm = instruction.immediate;
     if (instruction.shift_12) {
         imm <<= 12;

--- a/emulation/executors/data_proc_imm/AddSubImmediateExecutor.cpp
+++ b/emulation/executors/data_proc_imm/AddSubImmediateExecutor.cpp
@@ -33,10 +33,10 @@ void Executors::DataProcImm::AddSubImmediateExecutor::execute(
 
 	// SP is not writeable using ADDS/SUBS
 	// it's used as the destination then the result is to be discarded, for example when comparing values to 0 (CMP Xn, #0)
-	if (instruction.is_64bit) {
-		cpu.writeRegister64(instruction.destination_reg_index, result, !instruction.set_flags);
+	if (instruction.set_flags) {
+		cpu.writeRegister(instruction.destination_reg_index, result, instruction.is_64bit ? 64 : 32);
 	}
 	else {
-		cpu.writeRegister32(instruction.destination_reg_index, result, !instruction.set_flags);
+		cpu.writeRegisterSp(instruction.destination_reg_index, result, instruction.is_64bit ? 64 : 32);
 	}
 }

--- a/emulation/executors/data_proc_imm/FormPcRelAddressExecutor.cpp
+++ b/emulation/executors/data_proc_imm/FormPcRelAddressExecutor.cpp
@@ -20,7 +20,7 @@ void Executors::DataProcImm::FormPcRelAddressExecutor::execute(
 		result = pc + instruction.immediate;
 	}
 
-	cpu.writeRegister64(instruction.destination_reg_index, result);
+	cpu.writeRegister(instruction.destination_reg_index, result, 64);
 }
 
 

--- a/emulation/executors/data_proc_imm/LogicalImmediateExecutor.cpp
+++ b/emulation/executors/data_proc_imm/LogicalImmediateExecutor.cpp
@@ -33,5 +33,5 @@ void Executors::DataProcImm::LogicalImmediateExecutor::execute(
 			break;
 	}
 
-	cpu.writeRegister64(instruction.destinationReg, val, true);
+	cpu.writeRegisterSp(instruction.destinationReg, val, 64);
 }

--- a/emulation/executors/data_proc_imm/LogicalImmediateExecutor.cpp
+++ b/emulation/executors/data_proc_imm/LogicalImmediateExecutor.cpp
@@ -12,7 +12,7 @@ namespace {
 
 void Executors::DataProcImm::LogicalImmediateExecutor::execute(
 		const InstructionDefs::DataProcImm::LogicalImmediate &instruction, AArch64Cpu &cpu) {
-	uint64_t val = cpu.readRegister64(instruction.sourceReg);
+	uint64_t val = cpu.readRegister(instruction.sourceReg, 64);
 	switch (instruction.operation) {
 		case InstructionDefs::LogicalOperation::And:
 			val &= instruction.bitmask;

--- a/emulation/executors/data_proc_imm/MoveWideImmediateExecutor.cpp
+++ b/emulation/executors/data_proc_imm/MoveWideImmediateExecutor.cpp
@@ -13,9 +13,7 @@ void Executors::DataProcImm::MoveWideImmediateExecutor::execute(
 			result = instruction.immediate << instruction.left_shift;
 			break;
 		case InstructionDefs::DataProcImm::MoveWideImmediateOpType::KeepBits:
-			result = instruction.is_64bit
-					? cpu.readRegister64(instruction.destination_reg)
-					: cpu.readRegister32(instruction.destination_reg);
+			result = cpu.readRegister(instruction.destination_reg, instruction.is_64bit ? 64 : 32);
 			result &= ~(0b1111111111111111 << instruction.left_shift);
 			result |= (instruction.immediate << instruction.left_shift);
 			break;

--- a/emulation/executors/data_proc_imm/MoveWideImmediateExecutor.cpp
+++ b/emulation/executors/data_proc_imm/MoveWideImmediateExecutor.cpp
@@ -21,12 +21,7 @@ void Executors::DataProcImm::MoveWideImmediateExecutor::execute(
 			break;
 	}
 
-	if (instruction.is_64bit) {
-		cpu.writeRegister64(instruction.destination_reg, result);
-	}
-	else {
-		cpu.writeRegister32(instruction.destination_reg, result);
-	}
+	cpu.writeRegister(instruction.destination_reg, result, instruction.is_64bit ? 64 : 32);
 }
 
 

--- a/emulation/executors/data_proc_reg/AddSubExtendedRegisterExecutor.cpp
+++ b/emulation/executors/data_proc_reg/AddSubExtendedRegisterExecutor.cpp
@@ -49,13 +49,12 @@ namespace {
 
 void Executors::DataProcReg::AddSubExtendedRegisterExecutor::execute(
 		const AddSubExtendedRegister &details, AArch64Cpu &cpu) {
-	const uint64_t firstOperand = details.is64Bit
-			? cpu.readRegister64(details.firstSourceReg, true)
-			: cpu.readRegister32(details.firstSourceReg, true);
-	uint64_t secondOperand = details.is64Bit
+	const uint64_t firstOperand = cpu.readRegisterSp(details.firstSourceReg, details.is64Bit ? 64 : 32);
+	const size_t secondOpSize = details.is64Bit
 			&& (details.extendVariant == AddSubExtendedRegister::ExtendVariant::Sxtw || details.extendVariant == AddSubExtendedRegister::ExtendVariant::Uxtx)
-		    ? cpu.readRegister64(details.secondSourceReg)
-		    : cpu.readRegister32(details.secondSourceReg);
+		    ? 64
+		    : 32; // no sp
+	uint64_t secondOperand = cpu.readRegister(details.secondSourceReg, secondOpSize);
 	secondOperand = extend(secondOperand, details.extendVariant, details.is64Bit);
 	secondOperand <<= details.shiftAmount;
 

--- a/emulation/executors/data_proc_reg/AddSubExtendedRegisterExecutor.cpp
+++ b/emulation/executors/data_proc_reg/AddSubExtendedRegisterExecutor.cpp
@@ -67,11 +67,11 @@ void Executors::DataProcReg::AddSubExtendedRegisterExecutor::execute(
 	uint64_t nzcv;
 	if (details.is64Bit) {
 		auto result = Emulation::add_with_carry<uint64_t, int64_t>(firstOperand, secondOperand, false, nzcv);
-		cpu.writeRegister64(details.destinationReg, result, false);
+		cpu.writeRegister(details.destinationReg, result, 64);
 	}
 	else {
 		auto result = Emulation::add_with_carry<uint32_t, int32_t>(firstOperand, secondOperand, false, nzcv);
-		cpu.writeRegister32(details.destinationReg, result, false);
+		cpu.writeRegister(details.destinationReg, result, 64);
 	}
 
 	if (details.setFlags) {

--- a/emulation/executors/data_proc_reg/LogicalShiftedRegisterExecutor.cpp
+++ b/emulation/executors/data_proc_reg/LogicalShiftedRegisterExecutor.cpp
@@ -8,8 +8,8 @@ void Executors::DataProcReg::LogicalShiftedRegisterExecutor::execute(
         throw std::runtime_error("32-bit logical shifted reg. optional shift amount needs to be in the 0-31 range");
     }
 
-    uint64_t first = details.operand1Reg == 31 ? 0 : cpu.readRegister64(details.operand1Reg);
-    uint64_t second = details.operand2Reg == 31 ? 0 : cpu.readRegister64(details.operand2Reg);
+    uint64_t first = cpu.readRegister(details.operand1Reg, 64);
+    uint64_t second = cpu.readRegister(details.operand2Reg, 64);
 
     if (!details.is64Bit) {
         first &= std::numeric_limits<uint32_t>::max();

--- a/emulation/executors/data_proc_reg/LogicalShiftedRegisterExecutor.cpp
+++ b/emulation/executors/data_proc_reg/LogicalShiftedRegisterExecutor.cpp
@@ -66,10 +66,5 @@ void Executors::DataProcReg::LogicalShiftedRegisterExecutor::execute(
             throw std::runtime_error("Invalid operation");
     }
 
-    if (details.is64Bit) {
-		cpu.writeRegister64(details.destinationReg, result);
-    }
-    else {
-		cpu.writeRegister32(details.destinationReg, result);
-    }
+	cpu.writeRegister(details.destinationReg, result, details.is64Bit ? 64 : 32);
 }

--- a/emulation/executors/loads_and_stores/LoadStoreRegExecutor.cpp
+++ b/emulation/executors/loads_and_stores/LoadStoreRegExecutor.cpp
@@ -50,14 +50,7 @@ void Executors::LoadsAndStores::LoadStoreRegExecutor::execute(
 			}
 		}
 
-		if (instruction.isUsing64BitReg) {
-			cpu.writeRegister64(
-					instruction.targetReg, val);
-		}
-		else {
-			cpu.writeRegister32(
-					instruction.targetReg, val);
-		}
+		cpu.writeRegister(instruction.targetReg, val, instruction.isUsing64BitReg ? 64 : 32);
 	}
 	else {
 		if (instruction.isUsing64BitReg) {

--- a/emulation/executors/loads_and_stores/LoadStoreRegExecutor.cpp
+++ b/emulation/executors/loads_and_stores/LoadStoreRegExecutor.cpp
@@ -54,12 +54,12 @@ void Executors::LoadsAndStores::LoadStoreRegExecutor::execute(
 	}
 	else {
 		if (instruction.isUsing64BitReg) {
-			cpu.getMemory().write(
-					virtual_address, cpu.readRegister64(instruction.targetReg));
+			cpu.getMemory().write<uint64_t>(
+					virtual_address, cpu.readRegister(instruction.targetReg, 64));
 		}
 		else {
-			cpu.getMemory().write(
-					virtual_address, cpu.readRegister32(instruction.targetReg));
+			cpu.getMemory().write<uint32_t>(
+					virtual_address, cpu.readRegister(instruction.targetReg, 32));
 		}
 	}
 }

--- a/emulation/executors/loads_and_stores/LoadStoreRegExecutor.cpp
+++ b/emulation/executors/loads_and_stores/LoadStoreRegExecutor.cpp
@@ -54,11 +54,11 @@ void Executors::LoadsAndStores::LoadStoreRegExecutor::execute(
 	}
 	else {
 		if (instruction.isUsing64BitReg) {
-			cpu.getMemory().write<uint64_t>(
+			cpu.getMemory().write_u64(
 					virtual_address, cpu.readRegister(instruction.targetReg, 64));
 		}
 		else {
-			cpu.getMemory().write<uint32_t>(
+			cpu.getMemory().write_u32(
 					virtual_address, cpu.readRegister(instruction.targetReg, 32));
 		}
 	}

--- a/emulation/executors/loads_and_stores/LoadStoreRegPairExecutor.cpp
+++ b/emulation/executors/loads_and_stores/LoadStoreRegPairExecutor.cpp
@@ -26,10 +26,10 @@ void Executors::LoadsAndStores::LoadStoreRegPairExecutor::execute(
 		}
 		else {
 			if (instruction.is_wide) {
-				cpu.getMemory().write<uint64_t>(virtual_address, cpu.readRegister(reg_index, 64));
+				cpu.getMemory().write_u64(virtual_address, cpu.readRegister(reg_index, 64));
 			}
 			else {
-				cpu.getMemory().write<uint32_t>(virtual_address, cpu.readRegister(reg_index, 32));
+				cpu.getMemory().write_u32(virtual_address, cpu.readRegister(reg_index, 32));
 			}
 		}
 

--- a/emulation/executors/loads_and_stores/LoadStoreRegPairExecutor.cpp
+++ b/emulation/executors/loads_and_stores/LoadStoreRegPairExecutor.cpp
@@ -26,10 +26,10 @@ void Executors::LoadsAndStores::LoadStoreRegPairExecutor::execute(
 		}
 		else {
 			if (instruction.is_wide) {
-				cpu.getMemory().write(virtual_address, cpu.readRegister64(reg_index));
+				cpu.getMemory().write<uint64_t>(virtual_address, cpu.readRegister(reg_index, 64));
 			}
 			else {
-				cpu.getMemory().write(virtual_address, cpu.readRegister32(reg_index));
+				cpu.getMemory().write<uint32_t>(virtual_address, cpu.readRegister(reg_index, 32));
 			}
 		}
 

--- a/emulation/executors/loads_and_stores/LoadStoreRegPairExecutor.cpp
+++ b/emulation/executors/loads_and_stores/LoadStoreRegPairExecutor.cpp
@@ -18,10 +18,10 @@ void Executors::LoadsAndStores::LoadStoreRegPairExecutor::execute(
 	for (uint8_t reg_index : reg_indexes) {
 		if (instruction.is_load) {
 			if (instruction.is_wide) {
-				cpu.writeRegister64(reg_index, cpu.getMemory().read<uint64_t>(virtual_address));
+				cpu.writeRegister(reg_index, cpu.getMemory().read<uint64_t>(virtual_address), 64);
 			}
 			else {
-				cpu.writeRegister32(reg_index, cpu.getMemory().read<uint32_t>(virtual_address));
+				cpu.writeRegister(reg_index, cpu.getMemory().read<uint32_t>(virtual_address), 32);
 			}
 		}
 		else {

--- a/emulation/executors/loads_and_stores/LoadStoreRegUnsignedImm.cpp
+++ b/emulation/executors/loads_and_stores/LoadStoreRegUnsignedImm.cpp
@@ -64,12 +64,12 @@ void Executors::LoadsAndStores::LoadStoreRegUnsignedImm::execute(
 	}
 	else {
 		if (instruction.is_using_64bit_reg) {
-			cpu.getMemory().write(
-					virtual_address, cpu.readRegister64(instruction.src_dst_reg));
+			cpu.getMemory().write<uint64_t>(
+					virtual_address, cpu.readRegister(instruction.src_dst_reg, 64));
 		}
 		else {
-			cpu.getMemory().write(
-					virtual_address, cpu.readRegister32(instruction.src_dst_reg));
+			cpu.getMemory().write<uint32_t>(
+					virtual_address, cpu.readRegister(instruction.src_dst_reg, 32));
 		}
 	}
 }

--- a/emulation/executors/loads_and_stores/LoadStoreRegUnsignedImm.cpp
+++ b/emulation/executors/loads_and_stores/LoadStoreRegUnsignedImm.cpp
@@ -60,14 +60,7 @@ void Executors::LoadsAndStores::LoadStoreRegUnsignedImm::execute(
 			}
 		}
 
-		if (instruction.is_using_64bit_reg) {
-			cpu.writeRegister64(
-					instruction.src_dst_reg, val);
-		}
-		else {
-			cpu.writeRegister32(
-					instruction.src_dst_reg, val);
-		}
+		cpu.writeRegister(instruction.src_dst_reg, val, instruction.is_using_64bit_reg ? 64 : 32);
 	}
 	else {
 		if (instruction.is_using_64bit_reg) {

--- a/emulation/executors/loads_and_stores/LoadStoreRegUnsignedImm.cpp
+++ b/emulation/executors/loads_and_stores/LoadStoreRegUnsignedImm.cpp
@@ -64,11 +64,11 @@ void Executors::LoadsAndStores::LoadStoreRegUnsignedImm::execute(
 	}
 	else {
 		if (instruction.is_using_64bit_reg) {
-			cpu.getMemory().write<uint64_t>(
+			cpu.getMemory().write_u64(
 					virtual_address, cpu.readRegister(instruction.src_dst_reg, 64));
 		}
 		else {
-			cpu.getMemory().write<uint32_t>(
+			cpu.getMemory().write_u32(
 					virtual_address, cpu.readRegister(instruction.src_dst_reg, 32));
 		}
 	}

--- a/emulation/executors/reserved/ReservedCallExecutor.cpp
+++ b/emulation/executors/reserved/ReservedCallExecutor.cpp
@@ -8,7 +8,7 @@ void Executors::Reserved::ReservedCallExecutor::execute(const InstructionDefs::R
 		case InstructionDefs::Reserved::ReservedCalls::Exit: {
 			if (instruction.immediate == 0) {
 				_logger->info() << "Clean exit" << std::endl;
-				const int mainStatusCode = static_cast<int>(cpu.readRegister32(0));
+				const int mainStatusCode = static_cast<int>(cpu.readRegister(0, 32));
 				cpu.haltExecution(mainStatusCode);
 			}
 			break;

--- a/emulation/libraries/libc/FOpen.cpp
+++ b/emulation/libraries/libc/FOpen.cpp
@@ -1,8 +1,8 @@
 #include "FOpen.h"
 
 void Emulation::Libraries::LibC::FOpen::execute(AArch64Cpu &cpu) {
-	const virtual_address_t filename_char_ptr = cpu.readRegister64(0);
-	const virtual_address_t mode_char_ptr = cpu.readRegister64(1);
+	const virtual_address_t filename_char_ptr = cpu.readRegister(0, 64);
+	const virtual_address_t mode_char_ptr = cpu.readRegister(1, 64);
 
 	const auto path = cpu.getMemory().readCString(filename_char_ptr);
 	const auto mode = cpu.getMemory().readCString(mode_char_ptr);

--- a/emulation/libraries/libc/FOpen.cpp
+++ b/emulation/libraries/libc/FOpen.cpp
@@ -10,7 +10,7 @@ void Emulation::Libraries::LibC::FOpen::execute(AArch64Cpu &cpu) {
 	_logger->info() << "Opening: " << path << " (mode: " << mode << ")" << std::endl;
 
 	if (!cpu.getFs().doesFileExist(path)) {
-		cpu.writeRegister64(0, 0);
+		cpu.writeRegister(0, 0, 64);
 	}
 	else {
 		const auto fileId = cpu.getFs().getFile(path).getFileId();
@@ -19,6 +19,6 @@ void Emulation::Libraries::LibC::FOpen::execute(AArch64Cpu &cpu) {
 		const virtual_address_t virtualFileStructAddress = cpu.getMemory().allocateSegment(sizeof(Filesystem::VirtualFileStruct));
 		cpu.getMemory().write(virtualFileStructAddress, fileStruct);
 
-		cpu.writeRegister64(0, virtualFileStructAddress);
+		cpu.writeRegister(0, virtualFileStructAddress, 64);
 	}
 }

--- a/emulation/libraries/libc/FScanF.cpp
+++ b/emulation/libraries/libc/FScanF.cpp
@@ -1,9 +1,9 @@
 #include "FScanF.h"
 
 void Emulation::Libraries::LibC::FScanF::execute(AArch64Cpu &cpu) {
-	const virtual_address_t fileStructPtr = cpu.readRegister64(0);
-	const virtual_address_t formatCharPtr = cpu.readRegister64(1);
-	const virtual_address_t destinationBufferPtr = cpu.readRegister64(2);
+	const virtual_address_t fileStructPtr = cpu.readRegister(0, 64);
+	const virtual_address_t formatCharPtr = cpu.readRegister(1, 64);
+	const virtual_address_t destinationBufferPtr = cpu.readRegister(2, 64);
 
 	_logger->info() << "Reading file struct at " << std::hex << std::showbase << fileStructPtr << std::endl;
 

--- a/emulation/libraries/libc/LibCStartMain.cpp
+++ b/emulation/libraries/libc/LibCStartMain.cpp
@@ -15,12 +15,12 @@ void Emulation::Libraries::LibC::LibCStartMain::execute(AArch64Cpu &cpu) {
     // int main(int argc, char** argv),
     // X0 == argc
     // X1 == argv
-	cpu.writeRegister64(0, argc);
-	cpu.writeRegister64(1, argvPtr);
+	cpu.writeRegister(0, argc, 64);
+	cpu.writeRegister(1, argvPtr, 64);
 
     cpu.setProgramCounter(userEntryPointAddress);
 
     // this is a hack to jump to the clean address, because at this point LR is set to the instruction after __libc_start_main
     // which is abort().
-	cpu.writeRegister64(Registers::Lr, cpu.getCleanExitAddress());
+	cpu.writeRegister(30, cpu.getCleanExitAddress(), 64);
 }

--- a/emulation/libraries/libc/LibCStartMain.cpp
+++ b/emulation/libraries/libc/LibCStartMain.cpp
@@ -1,9 +1,9 @@
 #include "LibCStartMain.h"
 
 void Emulation::Libraries::LibC::LibCStartMain::execute(AArch64Cpu &cpu) {
-    const virtual_address_t userEntryPointAddress = cpu.readRegister64(0);
-    const int argc = static_cast<int>(cpu.readRegister64(1));
-    const virtual_address_t argvPtr = cpu.readRegister64(2);
+    const virtual_address_t userEntryPointAddress = cpu.readRegister(0, 64);
+    const int argc = static_cast<int>(cpu.readRegister(1, 64));
+    const virtual_address_t argvPtr = cpu.readRegister(2, 64);
 
     // X3 == init (unused)
     // X4 == fini (unused)

--- a/emulation/libraries/libc/Puts.cpp
+++ b/emulation/libraries/libc/Puts.cpp
@@ -6,5 +6,5 @@ void Emulation::Libraries::LibC::Puts::execute(AArch64Cpu &cpu) {
     const auto result = puts(str.c_str());
 
     // return value is written to X0
-	cpu.writeRegister64(0, result);
+	cpu.writeRegister(0, result, 64);
 }

--- a/emulation/libraries/libc/Puts.cpp
+++ b/emulation/libraries/libc/Puts.cpp
@@ -1,7 +1,7 @@
 #include "Puts.h"
 
 void Emulation::Libraries::LibC::Puts::execute(AArch64Cpu &cpu) {
-    const virtual_address_t charPtr = cpu.readRegister64(0);
+    const virtual_address_t charPtr = cpu.readRegister(0, 64);
     const std::string str = cpu.getMemory().readCString(charPtr);
     const auto result = puts(str.c_str());
 


### PR DESCRIPTION
Separating reads/writes of registers into two functions: 32-bit and 64-bit was unnecessary, because the executors were storing the values in a uint64_t anyways.